### PR TITLE
A trajectory conversion script in python

### DIFF
--- a/tools/conv.lammps.atom.dump.to.Mussic.py
+++ b/tools/conv.lammps.atom.dump.to.Mussic.py
@@ -1,0 +1,193 @@
+import re
+import math
+import numpy as np
+import multiprocessing as mp
+import time
+import sys
+import argparse
+
+def count_lines_streaming(filename):
+  line_count = 0
+  with open(filename, 'r') as f:
+    for _ in f:  # Iterate over lines without storing them
+      line_count += 1
+  return line_count
+
+def coord_lmp_to_xyz(lineStr, xLen, yLen, zLen):
+    line = lineStr.split()
+    xs, ys, zs = np.array(line[2:5], dtype=float) # scaled positions, floats
+    return f"{line[1]} {xs * xLen:.8f} {ys * yLen:.8f} {zs * zLen:.8f}\n"
+
+def process_lammps_file(input_file, output_file, everyNstep, cond="default"):
+    """
+    Reads a lammps trajectory file, extracts lattice parameters,
+    and writes the modified content to a new file for MuSSIC XYZ.
+
+    Args:
+        input_file (str): Path to the input xyz file.
+        output_file (str): Path to the output file.
+    """
+    #with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
+    success = True
+
+    input_nb_lines = count_lines_streaming(input_file)
+
+    infile = open(input_file, 'r')
+    outfile = open(output_file, 'w')
+
+    lineNb = 0
+    stepNb = 0
+    skipLines = 0
+    coordLines_to_read = 0
+    lastId = 0
+    num_atoms_this_step = 0
+    step_begin = True
+    
+    lattice_pattern = 'ITEM: BOX BOUNDS pp pp pp'
+    particles_pattern = 'ITEM: ATOMS id type xs ys zs'
+    timestep_pattern = 'ITEM: TIMESTEP'
+    num_atoms_pattern = 'ITEM: NUMBER OF ATOMS'
+    lattice_lohi_pattern = re.compile(r'(\d+\.\d+e[+-]\d+)\s(\d+\.\d+e[+-]\d+)')
+
+    while True:
+        line = infile.readline()
+        if not line: # end of file
+            break
+        lineNb += 1
+        progress = int(lineNb / input_nb_lines * 100)
+        print(f"Progress: {progress}%", end="\r")
+        
+        #print(f"the current lineNb is {lineNb}")
+        
+        if step_begin and timestep_pattern in line:
+            #stepNb = int(infile.readline())
+            line = infile.readline()
+            lineNb += 1
+            
+            if stepNb % everyNstep != 0: # Its a step to skip
+                skipLines = int(num_atoms_this_step) + 7 # add the other lines
+                try:
+                    [next(infile) for _ in range(skipLines)]
+                except:
+                    # reach end of file
+                    break
+                lineNb += skipLines
+                stepNb += 1
+                continue
+            
+            line = infile.readline()
+            lineNb += 1
+            if num_atoms_pattern not in line  : 
+                print("error timestep not followed by the number of atoms")
+                success = False
+                break
+            
+            num_atoms_this_step = infile.readline()
+            lineNb += 1
+
+            line = infile.readline()
+            lineNb += 1
+
+            if lattice_pattern not in line: 
+                print("error number of atoms not followed by the lattice")
+                success = False
+                break
+            
+            # read the three lines of box coordinates
+            xlo, xhi = np.array(lattice_lohi_pattern.search(infile.readline()).groups(), dtype=float)
+            ylo, yhi = np.array(lattice_lohi_pattern.search(infile.readline()).groups(), dtype=float)
+            zlo, zhi = np.array(lattice_lohi_pattern.search(infile.readline()).groups(), dtype=float)
+
+            # convert to lengths
+            xLen = abs(xlo-xhi)
+            yLen = abs(ylo-yhi)
+            zLen = abs(zlo-zhi)
+
+            lineNb += 3
+
+            outfile.write(f'{num_atoms_this_step}') # Write the number of atoms at the beginning of each steps
+            
+            # different syntax possible
+            if cond == "default":
+                outfile.write(f'{stepNb}\n') # default xyz format, write step number
+            elif cond == "NPT":
+                outfile.write(f'{xLen:.8f} {yLen:.8f} {zLen:.8f}\n') # NPT write box dimensions
+            elif cond == "NVT":
+                outfile.write('\n') # NVT write blank line
+            else:
+                print('Wrong cond option {cond}, should be "default" or "NVT" or "NPT"')
+                success = False
+                break
+
+            line = infile.readline() # should be ITEM: ATOMS id type xs ys zs
+            lineNb += 1
+            
+            if particles_pattern not in line: 
+                print("error not listing particles after box dimensions")
+                success = False
+                break
+
+            step_begin = False
+            coordLines_to_read = int(num_atoms_this_step) # inform next loops to read coordinates
+            
+            continue
+        # End of header
+        
+        elif coordLines_to_read > 0:
+            # read in block and convert all coordinates in parallel
+            
+            lineNb += coordLines_to_read - 1 # all those lines will be read
+            args0 = (line, xLen, yLen, zLen)
+            args = [(infile.readline(), xLen, yLen, zLen) for _ in range(coordLines_to_read-1)]
+            args.insert(0, args0)
+
+            with mp.Pool(numThreads) as pool:
+                convLines = pool.starmap(coord_lmp_to_xyz, args)
+                outfile.write("".join(convLines))
+            
+            step_begin = True
+            stepNb += 1
+            coordLines_to_read = -1
+        
+        else:
+            print(f"error expected beginning of step or coords to read, instead got {line} at line Nb {lineNb-1}")
+            success=False
+            break
+
+    
+    # End of file conversion - While True
+    infile.close()
+    outfile.close()
+    
+    return success
+# End of function process lammps
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Converts a lammps atom dump to xyz')
+    parser.add_argument('-input', required=True, type=str, help='Input dump file to convert')
+    parser.add_argument('-every', required=False, type=int, default=1, help='Convert one step every this many steps')
+    parser.add_argument('-cond', required=False, type=str, default="default", 
+        choices={"default", "NVT", "NPT"}, help='XYZ type: default, NVT (for MuSSIC) or NPT (for MuSSIC)')
+    parser.add_argument('-out', required=False, type=str, default="notDef", help='Output filename. If not specified, changes the extension to .formatted.xyz')
+    parser.add_argument('-np', required=False, type=int, default=None, help='Number of parallel processes. Default is the number of cores available')
+    args = parser.parse_args()
+
+    input_file = args.input
+    if args.out == "notDef":
+        # If not specified convert to a files with appendix ".formatted"
+        input_file_split = input_file.split(".")
+        #extension = input_file_split[-1]
+        filename = ".".join(input_file_split[:-1])
+        output_file = f'{filename}.formatted.xyz'
+    else:
+        output_file = args.out
+    everyNstep =  args.every
+    cond = args.cond
+    numThreads = args.np
+
+    tic = time.perf_counter()
+    result = process_lammps_file(input_file, output_file, everyNstep, cond)
+    toc = time.perf_counter()
+    if result:
+        print(f"Converted successfully lammps file: {input_file} to: {output_file} in {toc - tic:0.4f} seconds")
+


### PR DESCRIPTION
Hi,

I created this Python script that converts a LAMMPS dump file to a compatible xyz file.
If you think this would benefit to other people you could merge the script to your repo?

```
usage: conv.lammps.atom.dump.to.Mussic.py [-h] -input INPUT [-every EVERY] [-cond {NVT,NPT,default}] [-out OUT] [-np NP]

Converts a lammps atom dump to xyz

options:
  -h, --help            show this help message and exit
  -input INPUT          Input dump file to convert
  -every EVERY          Convert one step every this many steps
  -cond {NVT,NPT,default}
                        XYZ type: default, NVT (for MuSSIC) or NPT (for MuSSIC)
  -out OUT              Output filename. If not specified, changes the extension to .formatted.xyz
  -np NP                Number of parallel processes. Default is the number of cores available
```

Lammps dump using atom style from a command like this:

```
dump 1 all atom 2 trj.lammpsdump
```

Dump example:

```
ITEM: TIMESTEP
0
ITEM: NUMBER OF ATOMS
375000
ITEM: BOX BOUNDS pp pp pp
1.0855268630697559e+00 4.8914473136797739e+01
1.0855268630697559e+00 4.8914473136797739e+01
1.0855268630697559e+00 4.8914473136797739e+01
ITEM: ATOMS id type xs ys zs
1 3 0.753577 0.509664 0.753276
2 3 0.760084 0.5029 0.753169
3 3 0.76446 0.497874 0.75008
```

The coordinates are scaled, I needed to calculate the length of the box in each direction, then multiply the scaled coordinates by the length. I did not shift the unscaled coordinated by the low boundary value as your code is only waiting for box lengths, so I suppose the origin of the box is always (0,0,0). On the contrary, LAMMPS can move the box along the simulation, in the example above the origin is at (1.0855; 1.0855, 1.0855)

Converted xyz example:

```
375000
0
3 36.04279385 24.37669207 36.02839733
3 36.35401680 24.05317708 36.02327964
3 36.56331627 23.81278880 35.87553602
```

Conversion with '-cond NPT' argument:

```
375000
47.82894627 47.82894627 47.82894627
3 36.04279385 24.37669207 36.02839733
3 36.35401680 24.05317708 36.02327964
3 36.56331627 23.81278880 35.87553602
```